### PR TITLE
Make procs in :key evaluate with the PORO containing the specified columns

### DIFF
--- a/lib/transcryptor/active_record/re_encrypt_statement.rb
+++ b/lib/transcryptor/active_record/re_encrypt_statement.rb
@@ -1,8 +1,8 @@
 module Transcryptor::ActiveRecord::ReEncryptStatement
-  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {})
+  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {}, extra_columns = [])
     Transcryptor::Instance
       .new(Transcryptor::ActiveRecord::Adapter.new(self))
-      .re_encrypt(table_name, attribute_name, old_opts, new_opts)
+      .re_encrypt(table_name, attribute_name, old_opts, new_opts, extra_columns)
   end
 end
 

--- a/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
@@ -12,23 +12,22 @@ class ActiveRecordReEncryptStatementSpec < ActiveRecord::Base
   attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
 end
 
-ActiveRecord::Base.connection.create_table(:active_record_re_encrypt_statement_spec2s) do |t|
-  t.integer  :lucky_integer, default: 7
-  t.string   :encrypted_column_1
-  t.string   :encrypted_column_1_iv
-end
-
-class ActiveRecordReEncryptStatementSpec2 < ActiveRecord::Base
-  attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
-end
-
 class ReEncryptActiveRecordReEncryptStatementSpecColumn1 < ActiveRecord::Migration
   def up
     re_encrypt_column(
       :active_record_re_encrypt_statement_specs,
       :column_1,
       { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-      { key: '2asd2asd2asd2asd2asd2asd2asd2asd' }
+      { key: '2asd2asd2asd2asd2asd2asd2asd2asd' },
+    )
+  end
+
+  def down
+    re_encrypt_column(
+      :active_record_re_encrypt_statement_specs,
+      :column_1,
+      { key: '2asd2asd2asd2asd2asd2asd2asd2asd' },
+      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
     )
   end
 end
@@ -36,10 +35,20 @@ end
 class ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns < ActiveRecord::Migration
   def up
     re_encrypt_column(
-      :active_record_re_encrypt_statement_spec2s,
+      :active_record_re_encrypt_statement_specs,
       :column_1,
       { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
       { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
+      %i[lucky_integer]
+    )
+  end
+
+  def down
+    re_encrypt_column(
+      :active_record_re_encrypt_statement_specs,
+      :column_1,
+      { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
+      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
       %i[lucky_integer]
     )
   end
@@ -47,23 +56,34 @@ end
 
 describe Transcryptor::ActiveRecord::ReEncryptStatement do
 
+  before do
+    migration.migrate(:up)
+    ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = new_key
+  end
+
+  after do
+    migration.migrate(:down)
+  end
+
+  let(:expected_value) { 'my_value' }
+
   context 'with no extra columns specified' do
-    let!(:record) { ActiveRecordReEncryptStatementSpec.create!(column_1: 'my_value') }
+    let!(:record)   { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
+    let(:migration) { ReEncryptActiveRecordReEncryptStatementSpecColumn1 }
+    let(:new_key)   { '2asd2asd2asd2asd2asd2asd2asd2asd' }
 
     it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
-      ReEncryptActiveRecordReEncryptStatementSpecColumn1.migrate(:up)
-      ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = '2asd2asd2asd2asd2asd2asd2asd2asd'
-      expect(record.reload.column_1).to eq('my_value')
+      expect(record.reload.column_1).to eq(expected_value)
     end
   end
 
   context 'with extra columns specified' do
-    let!(:record) { ActiveRecordReEncryptStatementSpec2.create!(column_1: 'my_value') }
+    let!(:record)   { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
+    let(:migration) { ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns }
+    let(:new_key)   { '7asd7asd7asd7asd7asd7asd7asd7asd' }
 
     it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
-      ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns.migrate(:up)
-      ActiveRecordReEncryptStatementSpec2.encrypted_attributes[:column_1][:key] = '7asd7asd7asd7asd7asd7asd7asd7asd'
-      expect(record.reload.column_1).to eq('my_value')
+      expect(record.reload.column_1).to eq(expected_value)
     end
   end
 

--- a/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
@@ -3,11 +3,22 @@
 require 'spec_helper'
 
 ActiveRecord::Base.connection.create_table(:active_record_re_encrypt_statement_specs) do |t|
+  t.integer  :lucky_integer, default: 7
   t.string   :encrypted_column_1
   t.string   :encrypted_column_1_iv
 end
 
 class ActiveRecordReEncryptStatementSpec < ActiveRecord::Base
+  attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
+end
+
+ActiveRecord::Base.connection.create_table(:active_record_re_encrypt_statement_spec2s) do |t|
+  t.integer  :lucky_integer, default: 7
+  t.string   :encrypted_column_1
+  t.string   :encrypted_column_1_iv
+end
+
+class ActiveRecordReEncryptStatementSpec2 < ActiveRecord::Base
   attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
 end
 
@@ -22,12 +33,38 @@ class ReEncryptActiveRecordReEncryptStatementSpecColumn1 < ActiveRecord::Migrati
   end
 end
 
-describe Transcryptor::ActiveRecord::ReEncryptStatement do
-  let!(:record) { ActiveRecordReEncryptStatementSpec.create!(column_1: 'my_value') }
-
-  it 'appends #re_encrupt_column to ActiveRecord::Migration instance' do
-    ReEncryptActiveRecordReEncryptStatementSpecColumn1.migrate(:up)
-    ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = '2asd2asd2asd2asd2asd2asd2asd2asd'
-    expect(record.reload.column_1).to eq('my_value')
+class ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns < ActiveRecord::Migration
+  def up
+    re_encrypt_column(
+      :active_record_re_encrypt_statement_spec2s,
+      :column_1,
+      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+      { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
+      %i[lucky_integer]
+    )
   end
+end
+
+describe Transcryptor::ActiveRecord::ReEncryptStatement do
+
+  context 'with no extra columns specified' do
+    let!(:record) { ActiveRecordReEncryptStatementSpec.create!(column_1: 'my_value') }
+
+    it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
+      ReEncryptActiveRecordReEncryptStatementSpecColumn1.migrate(:up)
+      ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = '2asd2asd2asd2asd2asd2asd2asd2asd'
+      expect(record.reload.column_1).to eq('my_value')
+    end
+  end
+
+  context 'with extra columns specified' do
+    let!(:record) { ActiveRecordReEncryptStatementSpec2.create!(column_1: 'my_value') }
+
+    it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
+      ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns.migrate(:up)
+      ActiveRecordReEncryptStatementSpec2.encrypted_attributes[:column_1][:key] = '7asd7asd7asd7asd7asd7asd7asd7asd'
+      expect(record.reload.column_1).to eq('my_value')
+    end
+  end
+
 end


### PR DESCRIPTION
This approach makes the user to explicitly list out columns to be used so they are available inside the `:key => proc { ... }`s.

closes https://github.com/riboseinc/transcryptor/issues/22