### PR TITLE
Fix Migrating from schema with salt to without salt should set salt field to NULL

### DIFF
--- a/lib/transcryptor/abstract_adapter.rb
+++ b/lib/transcryptor/abstract_adapter.rb
@@ -23,6 +23,8 @@ class Transcryptor::AbstractAdapter
   end
 
   def update_query(table_name, old_values, new_values)
+    old_values.keys.each { |column_name| new_values[column_name] ||= nil }
+
     <<-SQL
       UPDATE #{table_name}
       SET #{equal_expressions(new_values).join(', ')}

--- a/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
@@ -55,7 +55,6 @@ class ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns < Activ
 end
 
 describe Transcryptor::ActiveRecord::ReEncryptStatement do
-
   before do
     migration.migrate(:up)
     ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = new_key
@@ -63,6 +62,7 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
 
   after do
     migration.migrate(:down)
+    ActiveRecordReEncryptStatementSpec.delete_all
   end
 
   let(:expected_value) { 'my_value' }
@@ -86,5 +86,4 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
       expect(record.reload.column_1).to eq(expected_value)
     end
   end
-
 end


### PR DESCRIPTION
When I run db:migrate, the keys.encrypted_stuff_salt fields should be set to NULL
Closes #21