### PR TITLE
Add pre-hooks and post-hooks around re-encryption of each row

### DIFF
--- a/lib/transcryptor/abstract_adapter.rb
+++ b/lib/transcryptor/abstract_adapter.rb
@@ -44,7 +44,7 @@ class Transcryptor::AbstractAdapter
     end
   end
 
-  def equal_expression(column, value)
+  def equal_expression(_column, _value)
     raise NotImplementedError, "#{self.class}#equal_expression not implemented"
   end
 end

--- a/lib/transcryptor/active_record/re_encrypt_statement.rb
+++ b/lib/transcryptor/active_record/re_encrypt_statement.rb
@@ -1,8 +1,8 @@
 module Transcryptor::ActiveRecord::ReEncryptStatement
-  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {}, extra_columns = [])
+  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {}, transcryptor_opts = {})
     Transcryptor::Instance
       .new(Transcryptor::ActiveRecord::Adapter.new(self))
-      .re_encrypt(table_name, attribute_name, old_opts, new_opts, extra_columns)
+      .re_encrypt(table_name, attribute_name, old_opts, new_opts, transcryptor_opts)
   end
 end
 

--- a/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'securerandom'
 
 ActiveRecord::Base.connection.create_table(:active_record_re_encrypt_statement_specs) do |t|
   t.integer  :lucky_integer, default: 7
@@ -12,65 +13,61 @@ class ActiveRecordReEncryptStatementSpec < ActiveRecord::Base
   attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
 end
 
-class ReEncryptActiveRecordReEncryptStatementSpecColumn1 < ActiveRecord::Migration
-  def up
-    re_encrypt_column(
-      :active_record_re_encrypt_statement_specs,
-      :column_1,
-      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-      { key: '2asd2asd2asd2asd2asd2asd2asd2asd' },
-    )
-  end
-
-  def down
-    re_encrypt_column(
-      :active_record_re_encrypt_statement_specs,
-      :column_1,
-      { key: '2asd2asd2asd2asd2asd2asd2asd2asd' },
-      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-    )
-  end
-end
-
-class ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns < ActiveRecord::Migration
-  def up
-    re_encrypt_column(
-      :active_record_re_encrypt_statement_specs,
-      :column_1,
-      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-      { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
-      %i[lucky_integer]
-    )
-  end
-
-  def down
-    re_encrypt_column(
-      :active_record_re_encrypt_statement_specs,
-      :column_1,
-      { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
-      { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-      %i[lucky_integer]
-    )
-  end
-end
-
 describe Transcryptor::ActiveRecord::ReEncryptStatement do
+
+  let(:migration) do
+    Kernel.const_set(
+      :"Migration#{SecureRandom.hex(4)}",
+      Class.new(ActiveRecord::Migration),
+    )
+  end
+
   before do
+    allow(migration).to receive(:up) do
+      migration.instance_exec(up_params) do |params|
+        re_encrypt_column(*params)
+      end
+    end
+
+    allow(migration).to receive(:down) do
+      migration.instance_exec(down_params) do |params|
+        re_encrypt_column(*params)
+      end
+    end
+
     migration.migrate(:up)
     ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = new_key
   end
+
+  let(:expected_value) { 'my_value' }
+  let!(:record) { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
 
   after do
     migration.migrate(:down)
     ActiveRecordReEncryptStatementSpec.delete_all
   end
 
-  let(:expected_value) { 'my_value' }
-
   context 'with no extra columns specified' do
-    let!(:record)   { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
-    let(:migration) { ReEncryptActiveRecordReEncryptStatementSpecColumn1 }
-    let(:new_key)   { '2asd2asd2asd2asd2asd2asd2asd2asd' }
+
+    let(:new_key) { '2asd2asd2asd2asd2asd2asd2asd2asd' }
+
+    let(:up_params) do
+      [
+        :active_record_re_encrypt_statement_specs,
+        :column_1,
+        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        { key: new_key },
+      ]
+    end
+
+    let(:down_params) do
+      [
+        :active_record_re_encrypt_statement_specs,
+        :column_1,
+        { key: new_key },
+        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+      ]
+    end
 
     it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
       expect(record.reload.column_1).to eq(expected_value)
@@ -78,9 +75,28 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
   end
 
   context 'with extra columns specified' do
-    let!(:record)   { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
-    let(:migration) { ReEncryptActiveRecordReEncryptStatementSpecColumn1WithExtraColumns }
-    let(:new_key)   { '7asd7asd7asd7asd7asd7asd7asd7asd' }
+
+    let(:new_key) { '7asd7asd7asd7asd7asd7asd7asd7asd' }
+
+    let(:up_params) do
+      [
+        :active_record_re_encrypt_statement_specs,
+        :column_1,
+        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
+        %i[lucky_integer],
+      ]
+    end
+
+    let(:down_params) do
+      [
+        :active_record_re_encrypt_statement_specs,
+        :column_1,
+        { key: ->(o) { new_key } },
+        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        %i[lucky_integer],
+      ]
+    end
 
     it 'appends #re_encrypt_column to ActiveRecord::Migration instance' do
       expect(record.reload.column_1).to eq(expected_value)

--- a/spec/transcryptor/instance_spec.rb
+++ b/spec/transcryptor/instance_spec.rb
@@ -132,7 +132,7 @@ describe Transcryptor::Instance do
             :column_1,
             { key: ->(poro) { "column_1_key_qwe_qwe_qwe_qwe_qwe" } },
             { key: ->(poro) { "column_1_key_asd_asd_asd_asd_as#{poro.lucky_integer}" } },
-            %i[lucky_integer lucky_string]
+            extra_columns: %i[lucky_integer lucky_string]
           )
         end
       end


### PR DESCRIPTION
This enables custom logging / housekeeping to be done, _e.g._ to keep a memo of which rows have successfully been re-encrypted (#15).