### PR TITLE
Null extra columns

### DIFF
--- a/lib/transcryptor.rb
+++ b/lib/transcryptor.rb
@@ -9,5 +9,6 @@ require 'transcryptor/active_record' if defined?(::ActiveRecord)
 require 'transcryptor/data_mapper' if defined?(::DataMapper)
 
 require 'attr_encrypted'
-require 'transcryptor/poro'
+require 'transcryptor/attr_encrypted'
+require 'transcryptor/encryption'
 require 'transcryptor/instance'

--- a/lib/transcryptor/abstract_adapter.rb
+++ b/lib/transcryptor/abstract_adapter.rb
@@ -23,8 +23,6 @@ class Transcryptor::AbstractAdapter
   end
 
   def update_query(table_name, old_values, new_values)
-    old_values.keys.each { |column_name| new_values[column_name] ||= nil }
-
     <<-SQL
       UPDATE #{table_name}
       SET #{equal_expressions(new_values).join(', ')}

--- a/lib/transcryptor/active_record.rb
+++ b/lib/transcryptor/active_record.rb
@@ -1,5 +1,4 @@
-module Transcryptor::ActiveRecord
-end
+module Transcryptor::ActiveRecord; end
 
 require 'transcryptor/active_record/adapter'
 require 'transcryptor/active_record/re_encrypt_statement'

--- a/lib/transcryptor/attr_encrypted.rb
+++ b/lib/transcryptor/attr_encrypted.rb
@@ -1,0 +1,4 @@
+module Transcryptor::AttrEncrypted; end
+
+require 'transcryptor/attr_encrypted/poro'
+require 'transcryptor/attr_encrypted/column_names'

--- a/lib/transcryptor/attr_encrypted/column_names.rb
+++ b/lib/transcryptor/attr_encrypted/column_names.rb
@@ -1,0 +1,42 @@
+module Transcryptor::AttrEncrypted::ColumnNames
+  private
+
+  def encrypted_column(attribute_name, opts)
+    "#{opts[:prefix]}#{attribute_name}#{opts[:suffix]}"
+  end
+
+  def encrypted_column_iv(attribute_name, opts)
+    "#{opts[:prefix]}#{attribute_name}#{opts[:suffix]}_iv"
+  end
+
+  def encrypted_column_salt(attribute_name, opts)
+    "#{opts[:prefix]}#{attribute_name}#{opts[:suffix]}_salt"
+  end
+
+  def column_names(attribute_name, opts)
+    column_names = [encrypted_column(attribute_name, opts)]
+
+    case opts[:mode].to_sym
+    when :per_attribute_iv
+      column_names << encrypted_column_iv(attribute_name, opts)
+    when :per_attribute_iv_and_salt
+      column_names << encrypted_column_iv(attribute_name, opts)
+      column_names << encrypted_column_salt(attribute_name, opts)
+    else
+    end
+
+    column_names
+  end
+
+  def column_names_with_extra_columns(attribute_name, old_opts, transcryptor_opts)
+    (column_names(attribute_name, old_opts) + transcryptor_opts[:extra_columns]).uniq
+  end
+
+  def column_names_to_nullify(attribute_name, new_opts, old_opts)
+    column_names(attribute_name, old_opts) - column_names(attribute_name, new_opts)
+  end
+
+  def column_names_to_update(attribute_name, new_opts, old_opts)
+    (column_names(attribute_name, old_opts) + column_names(attribute_name, new_opts)).uniq
+  end
+end

--- a/lib/transcryptor/attr_encrypted/poro.rb
+++ b/lib/transcryptor/attr_encrypted/poro.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-class Transcryptor::Poro
+class Transcryptor::AttrEncrypted::Poro
   extend AttrEncrypted
 
   def initialize(row = {})
     row.each do |column_name, column_value|
       instance_variable_set("@#{column_name}", column_value)
     end
+  end
+
+  def row
+    Hash[instance_variables.map { |name| [name[1..-1], instance_variable_get(name)] }]
   end
 end

--- a/lib/transcryptor/data_mapper.rb
+++ b/lib/transcryptor/data_mapper.rb
@@ -1,5 +1,4 @@
-module Transcryptor::DataMapper
-end
+module Transcryptor::DataMapper; end
 
 require 'transcryptor/data_mapper/adapter'
 require 'transcryptor/data_mapper/re_encrypt_statement'

--- a/lib/transcryptor/data_mapper/re_encrypt_statement.rb
+++ b/lib/transcryptor/data_mapper/re_encrypt_statement.rb
@@ -1,8 +1,8 @@
 module Transcryptor::DataMapper::ReEncryptStatement
-  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {})
+  def re_encrypt_column(table_name, attribute_name, old_opts = {}, new_opts = {}, transcryptor_opts = {})
     Transcryptor::Instance
       .new(Transcryptor::DataMapper::Adapter.new(self.adapter))
-      .re_encrypt(table_name, attribute_name, old_opts, new_opts)
+      .re_encrypt(table_name, attribute_name, old_opts, new_opts, transcryptor_opts)
   end
 end
 

--- a/lib/transcryptor/encryption.rb
+++ b/lib/transcryptor/encryption.rb
@@ -1,0 +1,5 @@
+module Transcryptor::Encryption; end
+
+require 'transcryptor/encryption/base'
+require 'transcryptor/encryption/decryptor'
+require 'transcryptor/encryption/encryptor'

--- a/lib/transcryptor/encryption/base.rb
+++ b/lib/transcryptor/encryption/base.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Transcryptor::Encryption::Base
+  include Transcryptor::AttrEncrypted::ColumnNames
+
+  def initialize(attribute_name, old_opts, new_opts, transcryptor_opts)
+    @attribute_name = attribute_name
+    @old_opts = old_opts
+    @new_opts = new_opts
+    @transcryptor_opts = transcryptor_opts
+  end
+
+  private
+
+  def attr_encrypted_poro_class(attr_encrypted_opts)
+    column_names_with_extra_columns =
+      column_names_with_extra_columns(@attribute_name, @old_opts, @transcryptor_opts)
+
+    attribute_name = @attribute_name
+
+    Class.new(Transcryptor::AttrEncrypted::Poro) do
+      attr_accessor(*column_names_with_extra_columns)
+      attr_encrypted(attribute_name, attr_encrypted_opts)
+    end
+  end
+end

--- a/lib/transcryptor/encryption/decryptor.rb
+++ b/lib/transcryptor/encryption/decryptor.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Transcryptor::Encryption::Decryptor < Transcryptor::Encryption::Base
+  def initialize(attribute_name, old_opts, new_opts, transcryptor_opts)
+    super
+    @decryptor_class = attr_encrypted_poro_class(@old_opts)
+  end
+
+  def decrypt(row)
+    call_before_decrypt_hook(row)
+    @decryptor_class.new(row).send(@attribute_name)
+  end
+
+  private
+
+  def call_before_decrypt_hook(row)
+    @transcryptor_opts[:before_decrypt].call(row, @decryptor_class)
+  end
+end

--- a/lib/transcryptor/encryption/encryptor.rb
+++ b/lib/transcryptor/encryption/encryptor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class Transcryptor::Encryption::Encryptor < Transcryptor::Encryption::Base
+  def initialize(attribute_name, old_opts, new_opts, transcryptor_opts)
+    super
+    @encryptor_class = attr_encrypted_poro_class(@new_opts)
+  end
+
+  def encrypt(decrypted_value, old_row)
+    encryptor_instance = @encryptor_class.new(old_row)
+    encryptor_instance.public_send("#{@attribute_name}=", decrypted_value)
+
+    nullify_row(encryptor_instance)
+
+    call_after_encrypt_hook(decrypted_value, encryptor_instance.row)
+
+    extract_row(encryptor_instance)
+  end
+
+  private
+
+  def nullify_row(encryptor_instance)
+    column_names_to_nullify = column_names_to_nullify(@attribute_name, @new_opts, @old_opts)
+
+    column_names_to_nullify.each do |column_name|
+      encryptor_instance.public_send("#{column_name}=", nil)
+    end
+  end
+
+  def extract_row(encryptor_instance)
+    column_names_to_update = column_names_to_update(@attribute_name, @new_opts, @old_opts)
+
+    column_names_to_update.each_with_object({}) do |column_name, row|
+      row[column_name] = encryptor_instance.public_send(column_name)
+    end
+  end
+
+  def call_after_encrypt_hook(decrypted_value, row)
+    @transcryptor_opts[:after_encrypt].call(decrypted_value, row, @encryptor_class)
+  end
+end

--- a/spec/transcryptor/abstract_adapter_spec.rb
+++ b/spec/transcryptor/abstract_adapter_spec.rb
@@ -1,5 +1,23 @@
 require 'spec_helper'
 
 describe Transcryptor::AbstractAdapter do
+  subject { described_class.new(connection) }
 
+  let(:connection) { double(:connection) }
+
+  describe '#select_rows' do
+    it 'raises NotImplementedError' do
+      expect{
+        subject.select_rows('table_name', { 'column' => 'value' })
+      }.to raise_error(NotImplementedError, "#{described_class}#select_rows not implemented")
+    end
+  end
+
+  describe '#update_row' do
+    it 'raises NotImplementedError' do
+      expect{
+        subject.update_row('table_name', { 'column' => 'old_value' }, { 'column' => 'new_value' })
+      }.to raise_error(NotImplementedError, "#{described_class}#update_row not implemented")
+    end
+  end
 end

--- a/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/active_record/re_encrypt_statement_spec.rb
@@ -9,9 +9,7 @@ ActiveRecord::Base.connection.create_table(:active_record_re_encrypt_statement_s
   t.string   :encrypted_column_1_iv
 end
 
-class ActiveRecordReEncryptStatementSpec < ActiveRecord::Base
-  attr_encrypted :column_1, key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe'
-end
+class ActiveRecordReEncryptStatementSpec < ActiveRecord::Base; end
 
 describe Transcryptor::ActiveRecord::ReEncryptStatement do
 
@@ -22,7 +20,19 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
     )
   end
 
+  let(:table_class) { ActiveRecordReEncryptStatementSpec }
+  let(:table_name) { :active_record_re_encrypt_statement_specs }
+  let(:column_name) { :column_1 }
+
   before do
+    table_class.delete_all
+
+    table_class.send(
+      :attr_encrypted,
+      column_name,
+      key: old_key
+    )
+
     allow(migration).to receive(:up) do
       migration.instance_exec(up_params) do |params|
         re_encrypt_column(*params)
@@ -35,34 +45,45 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
       end
     end
 
+    5.times do
+      table_class.create!(column_1: expected_value)
+    end
+
     migration.migrate(:up)
-    ActiveRecordReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = new_key
+    table_class.encrypted_attributes[column_name][:key] = new_key
   end
 
   let(:expected_value) { 'my_value' }
-  let(:record) { ActiveRecordReEncryptStatementSpec.create!(column_1: expected_value) }
+  let(:record) { table_class.last }
 
   after do
+    table_class.send(
+      :attr_encrypted,
+      column_name,
+      key: new_key
+    )
     migration.migrate(:down)
-    ActiveRecordReEncryptStatementSpec.delete_all
   end
+
+  let(:old_key) { '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' }
+  let(:old_configs) { { key: old_key } }
 
   context 'with no extra columns specified' do
     let(:new_key) { '2asd2asd2asd2asd2asd2asd2asd2asd' }
     let(:up_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-        { key: new_key }
+        table_name,
+        column_name,
+        old_configs,
+        { key: new_key },
       ]
     end
     let(:down_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
+        table_name,
+        column_name,
         { key: new_key },
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' }
+        old_configs,
       ]
     end
 
@@ -75,19 +96,19 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
     let(:new_key) { '7asd7asd7asd7asd7asd7asd7asd7asd' }
     let(:up_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        table_name,
+        column_name,
+        old_configs,
         { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
         extra_columns: %i[lucky_integer],
       ]
     end
     let(:down_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
-        { key: ->(o) { new_key } },
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        table_name,
+        column_name,
+        { key: ->(_o) { new_key } },
+        old_configs,
         extra_columns: %i[lucky_integer],
       ]
     end
@@ -98,40 +119,51 @@ describe Transcryptor::ActiveRecord::ReEncryptStatement do
   end
 
   context 'with extra columns and hooks specified' do
-    let(:before_decrypt_probe)  { spy(:before_decrypt_probe)  }
-    let(:after_encrypt_probe) { spy(:after_encrypt_probe) }
+
+    let(:before_decrypt_probe) { spy(:before_decrypt_probe) }
+    let(:after_encrypt_probe)  { spy(:after_encrypt_probe)  }
     let(:new_key) { '7asd7asd7asd7asd7asd7asd7asd7asd' }
+
     let(:up_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
+        table_name,
+        column_name,
+        old_configs,
         { key: ->(o) { '2asd2asd2asd2asd2asd2asd2asd2asd'.gsub(/2/, o.lucky_integer.to_s) } },
         extra_columns: %i[lucky_integer],
-        before_decrypt:  -> (old_row, decryptor_class) { before_decrypt_probe.call(old_row, decryptor_class) },
-        after_encrypt: -> (new_row, encryptor_class) { after_encrypt_probe.call(new_row, encryptor_class) }
+        before_decrypt: prehook,
+        after_encrypt:  posthook,
       ]
     end
+
     let(:down_params) do
       [
-        :active_record_re_encrypt_statement_specs,
-        :column_1,
-        { key: ->(o) { new_key } },
-        { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-        extra_columns: %i[lucky_integer]
+        table_name,
+        column_name,
+        { key: ->(_o) { new_key } },
+        old_configs,
+        extra_columns: %i[lucky_integer],
       ]
+    end
+
+    let(:prehook) do
+      -> (old_row, decryptor_class) { before_decrypt_probe.call(old_row, decryptor_class) }
+    end
+
+    let(:posthook) do
+      -> (new_row, encryptor_class) { after_encrypt_probe.call(new_row, encryptor_class) }
     end
 
     it 'calls before_decrypt hook' do
       expect(before_decrypt_probe).to have_received(:call).with(
-        hash_including(:column_1),
+        hash_including("encrypted_#{column_name}", "encrypted_#{column_name}_iv"),
         kind_of(Class)
       ).exactly(ActiveRecordReEncryptStatementSpec.count).times
     end
 
     it 'calls after_encrypt hook' do
       expect(after_encrypt_probe).to have_received(:call).with(
-        hash_including(:column_1),
+        hash_including("encrypted_#{column_name}", "encrypted_#{column_name}_iv"),
         kind_of(Class)
       ).exactly(ActiveRecordReEncryptStatementSpec.count).times
     end

--- a/spec/transcryptor/attr_encrypted/poro_spec.rb
+++ b/spec/transcryptor/attr_encrypted/poro_spec.rb
@@ -2,5 +2,5 @@
 
 require 'spec_helper'
 
-describe Transcryptor::Poro do
+describe Transcryptor::AttrEncrypted::Poro do
 end

--- a/spec/transcryptor/data_mapper/re_encrypt_statement_spec.rb
+++ b/spec/transcryptor/data_mapper/re_encrypt_statement_spec.rb
@@ -19,7 +19,7 @@ DataMapper.auto_migrate!
 describe Transcryptor::DataMapper::ReEncryptStatement do
   let!(:record) { DataMapperReEncryptStatementSpec.create!(column_1: 'my_value') }
 
-  it 'appends #re_encrupt_column to DataMapper::Migration instance' do
+  it 'appends #re_encrypt_column to DataMapper::Migration instance' do
     perform_data_mapper_migration
     DataMapperReEncryptStatementSpec.encrypted_attributes[:column_1][:key] = '2asd2asd2asd2asd2asd2asd2asd2asd'
     expect(record.reload.column_1).to eq('my_value')
@@ -32,7 +32,7 @@ describe Transcryptor::DataMapper::ReEncryptStatement do
           :data_mapper_re_encrypt_statement_specs,
           :column_1,
           { key: '1qwe1qwe1qwe1qwe1qwe1qwe1qwe1qwe' },
-          { key: '2asd2asd2asd2asd2asd2asd2asd2asd' }
+          { key: '2asd2asd2asd2asd2asd2asd2asd2asd' },
         )
       end
     end

--- a/spec/transcryptor/instance_spec.rb
+++ b/spec/transcryptor/instance_spec.rb
@@ -145,6 +145,28 @@ describe Transcryptor::Instance do
             transcryptor_opts
           )
         end
+
+        context 'and with hooks to check encrypted value equality' do
+
+          it 're-encrypts attribute' do
+            subject.re_encrypt(
+              table_name,
+              column_name,
+              old_configs,
+              new_configs,
+              transcryptor_opts.merge(
+                posthook: proc do |decrypted_value, new_row, encryptor_class|
+                  begin
+                    de_encrypted_value =
+                      encryptor_class.new(new_row).send(column_name)
+                  rescue => e
+                    raise e if de_encrypted_value != decrypted_value
+                  end
+                end
+              )
+            )
+          end
+        end
       end
 
     end

--- a/spec/transcryptor/instance_spec.rb
+++ b/spec/transcryptor/instance_spec.rb
@@ -34,52 +34,61 @@ describe Transcryptor::Instance do
   end
 
   describe '#re_encrypt' do
+
+    let(:column_name)  { :column_1 }
+    let(:table_name)   { :instance_specs }
+    let(:original_key) { 'column_1_key_qwe_qwe_qwe_qwe_qwe' }
+
+    let(:old_configs) do
+      { key: ->(poro) { original_key } }
+    end
+
+    let(:attr_encrypted_config_before) do
+      InstanceSpec.send(
+        :attr_encrypted, column_name,
+        old_configs
+      )
+    end
+
+    let(:attr_encrypted_config_after) do
+      InstanceSpec.send(
+        :attr_encrypted, column_name,
+        new_configs
+      )
+    end
+
     context 'from per_attribute_iv to per_attribute_iv_and_salt' do
-      let(:attr_encrypted_config_before) do
-        InstanceSpec.send(
-          :attr_encrypted, :column_1,
-          key: 'column_1_key_qwe_qwe_qwe_qwe_qwe', mode: :per_attribute_iv
-        )
+      let(:new_configs) do
+        { key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv_and_salt }
       end
 
-      let(:attr_encrypted_config_after) do
-        InstanceSpec.send(
-          :attr_encrypted, :column_1,
-          key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv_and_salt
-        )
-      end
-
-      it 're-encrypts attribute' do
+      it 'populates salt column' do
         subject.re_encrypt(
-          'instance_specs',
-          :column_1,
-          { key: 'column_1_key_qwe_qwe_qwe_qwe_qwe', mode: :per_attribute_iv },
-          { key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv_and_salt }
+          table_name,
+          column_name,
+          old_configs,
+          new_configs,
         )
+        expect(InstanceSpec.pluck(:encrypted_column_1_salt)).to_not include(nil)
       end
     end
 
     context 'from per_attribute_iv_and_salt to per_attribute_iv' do
-      let(:attr_encrypted_config_before) do
-        InstanceSpec.send(
-          :attr_encrypted, :column_1,
-          key: 'column_1_key_qwe_qwe_qwe_qwe_qwe', mode: :per_attribute_iv_and_salt
-        )
+
+      let(:old_configs) do
+        { key: original_key, mode: :per_attribute_iv_and_salt }
       end
 
-      let(:attr_encrypted_config_after) do
-        InstanceSpec.send(
-          :attr_encrypted, :column_1,
-          key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv
-        )
+      let(:new_configs) do
+        { key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv }
       end
 
       it 're-encrypts attribute' do
         subject.re_encrypt(
-          'instance_specs',
-          :column_1,
-          { key: 'column_1_key_qwe_qwe_qwe_qwe_qwe', mode: :per_attribute_iv_and_salt },
-          { key: 'column_1_key_asd_asd_asd_asd_asd', mode: :per_attribute_iv }
+          table_name,
+          column_name,
+          old_configs,
+          new_configs,
         )
         expect(InstanceSpec.pluck(:encrypted_column_1_salt)).to eq([nil, nil, nil])
       end
@@ -87,55 +96,57 @@ describe Transcryptor::Instance do
 
     context 'using lambda expression as a key' do
       context 'with no references to other columns' do
-        let(:attr_encrypted_config_before) do
-          InstanceSpec.send(
-            :attr_encrypted, :column_1,
-            key: ->(_instance_spec) { 'column_1_key_qwe_qwe_qwe_qwe_qwe' }
-          )
+
+        let(:old_configs) do
+          { key: ->(_instance_spec) { original_key } }
         end
 
-        let(:attr_encrypted_config_after) do
-          InstanceSpec.send(
-            :attr_encrypted, :column_1,
-            key: ->(_instance_spec) { 'column_1_key_asd_asd_asd_asd_asd' }
-          )
+        let(:new_configs) do
+          { key: ->(_instance_spec) { 'column_1_key_asd_asd_asd_asd_asd' } }
         end
 
         it 're-encrypts attribute' do
           subject.re_encrypt(
-            'instance_specs',
-            :column_1,
-            { key: ->(_instance_spec) { 'column_1_key_qwe_qwe_qwe_qwe_qwe' } },
-            { key: ->(_instance_spec) { 'column_1_key_asd_asd_asd_asd_asd' } }
+            table_name,
+            column_name,
+            old_configs,
+            new_configs,
           )
         end
       end
 
       context 'with references to other columns' do
-        let(:attr_encrypted_config_before) do
-          InstanceSpec.send(
-            :attr_encrypted, :column_1,
-            key: ->(_instance_spec) { 'column_1_key_qwe_qwe_qwe_qwe_qwe' }
-          )
+
+        let(:old_configs) do
+          { key: ->(_instance_spec) { original_key } }
         end
 
-        let(:attr_encrypted_config_after) do
-          InstanceSpec.send(
-            :attr_encrypted, :column_1,
-            key: ->(_instance_spec) { 'column_1_key_asd_asd_asd_asd_as7' }
-          )
+        let(:new_configs) do
+          {
+            key: proc do |poro|
+              expect(poro.lucky_integer).to_not be_nil
+              "column_1_key_asd_asd_asd_asd_as#{poro.lucky_integer}"
+            end
+          }
+        end
+
+        let(:transcryptor_opts) do
+          {
+            extra_columns: %i[lucky_integer lucky_string],
+          }
         end
 
         it 're-encrypts attribute' do
           subject.re_encrypt(
-            'instance_specs',
-            :column_1,
-            { key: ->(poro) { "column_1_key_qwe_qwe_qwe_qwe_qwe" } },
-            { key: ->(poro) { "column_1_key_asd_asd_asd_asd_as#{poro.lucky_integer}" } },
-            extra_columns: %i[lucky_integer lucky_string]
+            table_name,
+            column_name,
+            old_configs,
+            new_configs,
+            transcryptor_opts
           )
         end
       end
+
     end
   end
 end


### PR DESCRIPTION
   Add spec to check for validity of decrypted values.

Make sure the new encryption configs can actually decrypt.

With #21 (via #25), extra columns (i.e. those accessible in the key proc) would be set to NULL so re-decrypting wouldn't actually succeed.

This patch adds back those extra columns into the 'encryptor_class' so during its slicing of instance variables, those columns would get serialized into the resulting SQL statement and thus wouldn't be set to NULL regardless.